### PR TITLE
Removed deprecated Gemfile option

### DIFF
--- a/oauth2-provider.gemspec
+++ b/oauth2-provider.gemspec
@@ -6,7 +6,6 @@ spec = Gem::Specification.new do |s|
   s.email             = "james@songkick.com"
   s.homepage          = "http://www.songkick.com"
 
-  s.has_rdoc          = true
   s.extra_rdoc_files  = %w(README.rdoc)
   s.rdoc_options      = %w(--main README.rdoc)
 


### PR DESCRIPTION
The line was generating the warning:
NOTE: Gem::Specification#has_rdoc= is deprecated with no replacement. It will be removed on or after 2011-10-01.
with rubygems 1.8.4.
