### PR TITLE
Fix authorization mass assignment

### DIFF
--- a/lib/oauth2/model/authorization.rb
+++ b/lib/oauth2/model/authorization.rb
@@ -25,7 +25,13 @@ module OAuth2
       end
 
       def self.find_or_new(owner, client)
-        self.for(owner, client) || new(:owner => owner, :client => client)
+        instance = self.for(owner, client)
+        unless instance
+          instance = new
+          instance.owner  = owner
+          instance.client = client
+        end
+        instance
       end
       
       def self.create_code(client)

--- a/spec/oauth2/model/authorization_spec.rb
+++ b/spec/oauth2/model/authorization_spec.rb
@@ -38,16 +38,26 @@ describe OAuth2::Model::Authorization do
       end
     end
     describe "when it does not find an existing object" do
-      it "creates a new object" do
+      def create_and_test_new_object
         a = OAuth2::Model::Authorization.find_or_new(owner, client2)
         a.class.should eq(OAuth2::Model::Authorization)
         a.should_not be_persisted
         a.client.should eq(client2)
         a.owner.should eq(owner)
         a.save.should be_true
+      end
+
+      it "creates a new object" do
+        create_and_test_new_object
       end    
-    end
-  
+      it "creates a new object even if attr_accessible is empty" do
+        old = OAuth2::Model::Authorization._accessible_attributes
+        OAuth2::Model::Authorization.send(:attr_accessible, nil)
+        create_and_test_new_object
+        OAuth2::Model::Authorization._accessible_attributes = old
+        OAuth2::Model::Authorization._active_authorizer = old
+      end
+    end  
   end
 
   describe "when there are existing authorizations" do


### PR DESCRIPTION
In my app I have accessible attributes set to empty globally, which forces each model to define its own whitelist.

``` ruby
ActiveRecord::Base.send(:attr_accessible, nil)
```

This is a pretty common practice AFAIK. Because of this, creating a new `OAuth2::Model::Authorization` in `OAuth2::Model::Authorization.for_response_type` was failing for me.

This patch accommodates such environments.
