### PR TITLE
Updated Authorization header token lookup to allow the "Bearer" prefix

### DIFF
--- a/lib/oauth2/router.rb
+++ b/lib/oauth2/router.rb
@@ -42,8 +42,8 @@ module OAuth2
         params  = request.params
         header  = request.env['HTTP_AUTHORIZATION']
         
-        header && header =~ /^OAuth\s+/ ?
-            header.gsub(/^OAuth\s+/, '') :
+        header && header =~ /^(OAuth|Bearer)\s+/ ?
+            header.gsub(/^(OAuth|Bearer)\s+/, '') :
             params[OAUTH_TOKEN]
       end
       

--- a/spec/oauth2/provider_spec.rb
+++ b/spec/oauth2/provider_spec.rb
@@ -518,7 +518,7 @@ describe OAuth2::Provider do
       end
     end
     
-    describe "for header-based requests" do
+    describe "for header-based requests using the OAuth prefix" do
       def request(path, params = {})
         access_token = params.delete('oauth_token')
         http   = Net::HTTP.new('localhost', 8000)
@@ -530,6 +530,18 @@ describe OAuth2::Provider do
       it_should_behave_like "protected resource"
     end
     
+    describe "for header-based requests using the Bearer prefix" do
+      def request(path, params = {})
+        access_token = params.delete('oauth_token')
+        http   = Net::HTTP.new('localhost', 8000)
+        qs     = params.map { |k,v| "#{ CGI.escape k.to_s }=#{ CGI.escape v.to_s }" }.join('&')
+        header = {'Authorization' => "Bearer #{access_token}"}
+        http.request_get(path + '?' + qs, header)
+      end
+      
+      it_should_behave_like "protected resource"
+    end
+
     describe "for GET requests" do
       def request(path, params = {})
         qs  = params.map { |k,v| "#{ CGI.escape k.to_s }=#{ CGI.escape v.to_s }" }.join('&')


### PR DESCRIPTION
From what I can tell, the current standard is to use the "Bearer" keyword in the Authorization header, instead of "OAuth" as this gem currently has it implemented. I changed it to support the newer keyword, but kept compatibility with the OAuth prefix for those relying on that behavior. Specs included as well.
