### PR TITLE
Fixed deprecation warning on set_table_name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 Gemfile.lock
 pkg
 rdoc
+.idea

--- a/lib/oauth2/model/authorization.rb
+++ b/lib/oauth2/model/authorization.rb
@@ -2,7 +2,7 @@ module OAuth2
   module Model
     
     class Authorization < ActiveRecord::Base
-      set_table_name :oauth2_authorizations
+      self.table_name = :oauth2_authorizations
       
       belongs_to :oauth2_resource_owner, :polymorphic => true
       alias :owner  :oauth2_resource_owner

--- a/lib/oauth2/model/client.rb
+++ b/lib/oauth2/model/client.rb
@@ -2,7 +2,7 @@ module OAuth2
   module Model
     
     class Client < ActiveRecord::Base
-      set_table_name :oauth2_clients
+      self.table_name = :oauth2_clients
       
       belongs_to :oauth2_client_owner, :polymorphic => true
       alias :owner  :oauth2_client_owner

--- a/oauth2-provider.gemspec
+++ b/oauth2-provider.gemspec
@@ -17,7 +17,7 @@ spec = Gem::Specification.new do |s|
   s.add_dependency("json")
   s.add_dependency("rack")
 
-  s.add_development_dependency("activerecord", "~> 3.0.0") # The SQLite adapter in 3.1 is broken
+  s.add_development_dependency("activerecord", "~> 3.0.0")
   s.add_development_dependency("rspec")
   s.add_development_dependency("sqlite3-ruby")
   s.add_development_dependency("sinatra", ">= 1.3.0")

--- a/spec/test_app/helper.rb
+++ b/spec/test_app/helper.rb
@@ -1,7 +1,7 @@
 module TestApp
   
   class User < ActiveRecord::Base
-    set_table_name :users
+    self.table_name = :users
     
     include OAuth2::Model::ResourceOwner
     include OAuth2::Model::ClientOwner


### PR DESCRIPTION
For people using active_record >= 3.2
