### PR TITLE
Fix post-install message when installing development dependencies.

### DIFF
--- a/oauth2-provider.gemspec
+++ b/oauth2-provider.gemspec
@@ -19,7 +19,7 @@ spec = Gem::Specification.new do |s|
 
   s.add_development_dependency("activerecord", "~> 3.0.0") # The SQLite adapter in 3.1 is broken
   s.add_development_dependency("rspec")
-  s.add_development_dependency("sqlite3-ruby")
+  s.add_development_dependency("sqlite3")
   s.add_development_dependency("sinatra", ">= 1.3.0")
   s.add_development_dependency("thin")
   s.add_development_dependency("factory_girl", "~> 2.0")


### PR DESCRIPTION
The gem specification file references `sqlite3-ruby`. The gem has been renamed to `sqlite3`. The gem still installs but it's not quite clear for how long they are going to provide the library under the old gem name. (Rails is also referencing `sqlite3` rather than `sqlite3-ruby`.

This commit updates the development dependency and gets rid of the post-install message:

'Hello! The sqlite3-ruby gem has changed it's name to just sqlite3. Rather than installing `sqlite3-ruby`, you should install `sqlite3`. Please update your dependencies accordingly'.
