### PR TITLE
issues with grant_access with scopes

### DIFF
--- a/lib/oauth2/model/authorization.rb
+++ b/lib/oauth2/model/authorization.rb
@@ -67,7 +67,7 @@ module OAuth2
         end
         
         if attributes[:scope]
-          scopes = instance.scopes + attributes[:scope].split(/\s+/)
+          scopes = attributes[:scope].split(/\s+/)
           instance.scope = scopes.join(' ')
         end
         


### PR DESCRIPTION
When you do grant_access! with scopes we always add new scope to old ones, it will cause very long string of equal scopes as a result. Instead of add replace scope each time. 
