### PR TITLE
Move authorization find/create for client to model

### DIFF
--- a/lib/oauth2/model/authorization.rb
+++ b/lib/oauth2/model/authorization.rb
@@ -16,7 +16,7 @@ module OAuth2
       validates_uniqueness_of :refresh_token_hash, :scope => :client_id, :allow_nil => true
       validates_uniqueness_of :access_token_hash,                        :allow_nil => true
       
-      attr_accessible nil
+      attr_accessible :client
       
       extend Hashing
       hashes_attributes :access_token, :refresh_token
@@ -77,6 +77,14 @@ module OAuth2
         end
         
         instance.save && instance
+      end
+      
+      def self.find_or_create_for_client(client)
+        unless client.is_a?(Client)
+          raise ArgumentError, "The argument should be a #{Client}, instead it was a #{client.class}"
+        end
+        
+        find_by_client_id(client.id) || create(:client => client)
       end
       
       def exchange!

--- a/lib/oauth2/model/resource_owner.rb
+++ b/lib/oauth2/model/resource_owner.rb
@@ -10,11 +10,7 @@ module OAuth2
       end
       
       def grant_access!(client, options = {})
-        authorization = oauth2_authorizations.find_by_client_id(client.id) ||
-                        Authorization.create do |authorization|
-                          authorization.owner  = self
-                          authorization.client = client
-                        end
+        authorization = oauth2_authorizations.find_or_create_for_client(client)
 
         if scopes = options[:scopes]
           scopes = authorization.scopes + scopes

--- a/spec/oauth2/model/resource_owner_spec.rb
+++ b/spec/oauth2/model/resource_owner_spec.rb
@@ -7,14 +7,12 @@ describe OAuth2::Model::ResourceOwner do
   end
   
   describe "#grant_access!" do
+    it "raises an error when passed an invalid client argument" do
+      lambda{ @owner.grant_access!('client') }.should raise_error(ArgumentError)
+    end
+    
     it "creates an authorization between the owner and the client" do
-      # This absolute clusterfuck brought to you by ActiveRecord::Base.attr_accessible
-      authorization = mock(OAuth2::Model::Authorization)
-      
-      OAuth2::Model::Authorization.should_receive(:create).and_yield(authorization)
-      authorization.should_receive('owner=').with(@owner)
-      authorization.should_receive('client=').with(@client)
-      
+      OAuth2::Model::Authorization.should_receive(:create).with(:client => @client)      
       @owner.grant_access!(@client)
     end
     


### PR DESCRIPTION
By defining the class method and calling it through the association
Active Record automatically assigns the owner so it's not needed in
grant_access!

By using attr_accessible :client it allows passing the client through
the attributes hash but prevents injected params assigning client_id.
The is_a? check is not strictly necessary as Active Record will blow
up when trying to assign a literal to a association, it's just there
to provide a more helpful error message.

It may be preferable to use create! rather than create in
find_or_create_for_client as no checking is done to see whether the
save was successful.
