### PR TITLE
Fix bug in find_or_create_for_client

### DIFF
--- a/lib/oauth2/model/resource_owner.rb
+++ b/lib/oauth2/model/resource_owner.rb
@@ -7,10 +7,10 @@ module OAuth2
           raise ArgumentError, "The argument should be a #{Client}, instead it was a #{client.class}"
         end
 
-        authorization = find_or_create_by_client_id(client.id)
-        authorization.client = client
-        authorization.owner = owner
-        authorization
+        find_or_create_by_client_id(client.id) do |auth|
+          auth.client = client
+          auth.owner  = owner
+        end
       end
 
     private

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,6 +7,8 @@ require 'bundler/setup'
 
 require 'active_record'
 require 'oauth2/provider'
+require 'pry'
+require 'pry-nav'
 
 ActiveRecord::Base.establish_connection(:adapter  => 'sqlite3', :database => 'test.sqlite3')
 


### PR DESCRIPTION
The test was failing because a validation was failing on the
authorization generated by find_or_create_by_client_id. The reason is
that you validate_presence_of :client, but you are doing
find_or_create_by_client_id, so the :client attribute is not set and
validation fails.

Solution is to just set the client and owner in the find_or_create block
that ActiveRecord provides.
