### PR TITLE
Allow OAuth clients using more recent draft versions to work as well

### DIFF
--- a/lib/songkick/oauth2/router.rb
+++ b/lib/songkick/oauth2/router.rb
@@ -44,8 +44,8 @@ module Songkick
           params  = request.params
           header  = request.env['HTTP_AUTHORIZATION']
           
-          header && header =~ /^OAuth\s+/ ?
-              header.gsub(/^OAuth\s+/, '') :
+          header && header =~ /^(OAuth|Bearer)\s+/ ?
+              header.gsub(/^(OAuth|Bearer)\s+/, '') :
               params[OAUTH_TOKEN]
         end
         


### PR DESCRIPTION
In older OAuth drafts, the method used in the `Authorization` HTTP header was `OAuth`; in more recent drafts, this changed to `Bearer`. To make more recent clients just work with this provider, it makes sense to accept both.
