### PR TITLE
Support query string separator for all callbacks.

### DIFF
--- a/lib/songkick/oauth2/provider/authorization.rb
+++ b/lib/songkick/oauth2/provider/authorization.rb
@@ -101,7 +101,7 @@ module Songkick
           
           else
             query = to_query_string(CODE, SCOPE, STATE)
-            "#{ base_redirect_uri }?#{ query }"
+            "#{ base_redirect_uri }#{ q }#{ query }"
           end
         end
         

--- a/spec/songkick/oauth2/provider/authorization_spec.rb
+++ b/spec/songkick/oauth2/provider/authorization_spec.rb
@@ -132,6 +132,17 @@ describe Songkick::OAuth2::Provider::Authorization do
     end
   end
   
+  describe "with a redirect_uri with parameters" do
+    before do
+      authorization.client.redirect_uri = "http://songkick.com?some_parameter"
+      params['redirect_uri'] = "http://songkick.com?some_parameter"
+    end
+
+    it "adds the extra parameters with & instead of ?" do
+      authorization.redirect_uri.should == "http://songkick.com?some_parameter&"
+    end
+  end
+
   # http://en.wikipedia.org/wiki/HTTP_response_splitting
   # scope and state values are passed back in the redirect
   


### PR DESCRIPTION
In commit 863a62adaeba56a5f8f74aa0e8f2f9c98f9ba0c2 support for callback uris
with query strings was added, but the default case was not adapted.
