### PR TITLE
Add example Gemfile entry to README

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -3,6 +3,8 @@
 {<img src="https://secure.travis-ci.org/songkick/oauth2-provider.png?branch=master" alt="Build Status" />}[http://travis-ci.org/songkick/oauth2-provider]
 {<img src="https://codeclimate.com/badge.png" />}[https://codeclimate.com/github/songkick/oauth2-provider]
 
+  gem 'songkick-oauth2-provider'
+
 This gem provides a toolkit for adding OAuth2 provider capabilities to a Ruby
 web app. It handles most of the protocol for you: it is designed to provide
 a sufficient level of abstraction that it can implement updates to the protocol


### PR DESCRIPTION
The gem name doesn't match the repo which might be confusing to people, especially since 'oauth2-provider' is a real (different) gem.
