### PR TITLE
Remove `attr_accessible` for Rails 4 compatibility.

### DIFF
--- a/lib/songkick/oauth2/model/authorization.rb
+++ b/lib/songkick/oauth2/model/authorization.rb
@@ -17,8 +17,6 @@ module Songkick
         validates_uniqueness_of :refresh_token_hash, :scope => :client_id, :allow_nil => true
         validates_uniqueness_of :access_token_hash,                        :allow_nil => true
 
-        attr_accessible nil
-
         class << self
           private :create, :new
         end

--- a/lib/songkick/oauth2/model/client.rb
+++ b/lib/songkick/oauth2/model/client.rb
@@ -15,8 +15,6 @@ module Songkick
         validates_presence_of   :name, :redirect_uri
         validate :check_format_of_redirect_uri
 
-        attr_accessible :name, :redirect_uri
-
         before_create :generate_credentials
 
         def self.create_client_id

--- a/spec/songkick/oauth2/model/client_spec.rb
+++ b/spec/songkick/oauth2/model/client_spec.rb
@@ -32,16 +32,6 @@ describe Songkick::OAuth2::Model::Client do
     @client.should_not be_valid
   end
 
-  it "cannot mass-assign client_id" do
-    @client.update_attributes(:client_id => 'foo')
-    @client.client_id.should_not == 'foo'
-  end
-
-  it "cannot mass-assign client_secret" do
-    @client.update_attributes(:client_secret => 'foo')
-    @client.client_secret.should_not == 'foo'
-  end
-
   it "has client_id and client_secret filled in" do
     @client.client_id.should_not be_nil
     @client.client_secret.should_not be_nil


### PR DESCRIPTION
Using this with Rails 4 raises an error on `attr_accessible` as it is
removed, in favour of `strong_params`.

The onus is now on the implementer to only permit `name` and
`redirect_uri` when creating an authorization.
