### PR TITLE
Persist the current resource owner through the assertion handler

### DIFF
--- a/lib/songkick/oauth2/provider.rb
+++ b/lib/songkick/oauth2/provider.rb
@@ -112,10 +112,10 @@ module Songkick
         @assertion_handlers[assertion_type] = handler
       end
 
-      def self.handle_assertion(client, assertion, scopes)
+      def self.handle_assertion(client, assertion, scopes, resource_owner)
         return nil unless @assertion_filters.all? { |f| f.call(client) }
         handler = @assertion_handlers[assertion.type]
-        handler ? handler.call(client, assertion.value, scopes) : nil
+        handler ? handler.call(client, assertion.value, scopes, resource_owner) : nil
       end
 
       def self.parse(*args)
@@ -133,4 +133,3 @@ module Songkick
 
   end
 end
-

--- a/lib/songkick/oauth2/provider/exchange.rb
+++ b/lib/songkick/oauth2/provider/exchange.rb
@@ -17,9 +17,10 @@ module Songkick
         }
 
         def initialize(resource_owner, params, transport_error = nil)
-          @params     = params
-          @scope      = params[SCOPE]
-          @grant_type = @params[GRANT_TYPE]
+          @params          = params
+          @scope           = params[SCOPE]
+          @grant_type      = @params[GRANT_TYPE]
+          @resource_owner  = resource_owner
 
           @transport_error = transport_error
 
@@ -187,7 +188,7 @@ module Songkick
           return if @error
 
           assertion = Assertion.new(@params)
-          @authorization = Provider.handle_assertion(@client, assertion, scopes)
+          @authorization = Provider.handle_assertion(@client, assertion, scopes, @resource_owner)
           return validate_authorization if @authorization
 
           @error = UNAUTHORIZED_CLIENT
@@ -224,4 +225,3 @@ module Songkick
     end
   end
 end
-

--- a/spec/songkick/oauth2/provider/exchange_spec.rb
+++ b/spec/songkick/oauth2/provider/exchange_spec.rb
@@ -269,6 +269,15 @@ describe Songkick::OAuth2::Provider::Exchange do
     it_should_behave_like "validates required parameters"
     it_should_behave_like "valid token request"
 
+    it "provides the resource_owner to the assertion handler" do
+      Songkick::OAuth2::Provider.handle_assertions('https://graph.facebook.com/me') do |client, assertion, scopes, resource_owner|
+        resource_owner.should be_a TestApp::User
+        user = TestApp::User[assertion]
+        user.grant_access!(client, :scopes => ['foo', 'bar'])
+      end
+      exchange
+    end
+
     describe "missing assertion_type" do
       before { params.delete('assertion_type') }
 
@@ -350,4 +359,3 @@ describe Songkick::OAuth2::Provider::Exchange do
 
   end
 end
-


### PR DESCRIPTION
This is intended to allow assertion handlers to have context to the current resource owner if it is provided by parse call.

Specifically meant to allow a user to associate social networks to their existing and authorized account in an api via assertions.
