### PR TITLE
Make the client URI error less generic

### DIFF
--- a/lib/songkick/oauth2/model/client.rb
+++ b/lib/songkick/oauth2/model/client.rb
@@ -43,8 +43,8 @@ module Songkick
         def check_format_of_redirect_uri
           uri = URI.parse(redirect_uri)
           errors.add(:redirect_uri, 'must be an absolute URI') unless uri.absolute?
-        rescue
-          errors.add(:redirect_uri, 'must be a URI')
+        rescue Exception => error
+          errors.add(:redirect_uri, "must be a URI: #{error.message}")
         end
 
         def generate_credentials

--- a/spec/songkick/oauth2/model/client_spec.rb
+++ b/spec/songkick/oauth2/model/client_spec.rb
@@ -16,6 +16,12 @@ describe Songkick::OAuth2::Model::Client do
     @client.should_not be_valid
   end
 
+  it "gives an appropriate message for an invalid uri" do
+    @client.redirect_uri = "http://underscore_uri_not_valid/receive_token"
+    @client.should_not be_valid
+    @client.errors[:redirect_uri].first.should eq("must be a URI: the scheme http does not accept registry part: underscore_uri_not_valid (or bad hostname?)")
+  end
+
   it "is invalid without a redirect_uri" do
     @client.redirect_uri = nil
     @client.should_not be_valid


### PR DESCRIPTION
Rather than catching the generic uri exception and just throwing back a generic error message, a useful error message would be much more useful.
