### PR TITLE
freezing the RESPONSE_HEADERS constant

### DIFF
--- a/lib/songkick/oauth2/provider/exchange.rb
+++ b/lib/songkick/oauth2/provider/exchange.rb
@@ -14,7 +14,7 @@ module Songkick
         RESPONSE_HEADERS = {
           'Cache-Control' => 'no-store',
           'Content-Type'  => 'application/json'
-        }
+        }.freeze
 
         def initialize(resource_owner, params, transport_error = nil)
           @params     = params


### PR DESCRIPTION
Freezing the `RESPONSE_HEADERS` would help prevent unintended modifications.
While this constant should definitely be merged into the headers, if someone ever did:

``` ruby
request.headers = @oauth2.response_headers
```

The `request.headers` would become a pointer to the constant, so adding or modifying any headers after this would actually modify the constant

Tests pass with https://github.com/songkick/oauth2-provider/pull/74
