### PR TITLE
Set refresh token

### DIFF
--- a/lib/songkick/oauth2/model/authorization.rb
+++ b/lib/songkick/oauth2/model/authorization.rb
@@ -94,7 +94,7 @@ module Songkick
         def exchange!
           self.code          = nil
           self.access_token  = self.class.create_access_token
-          self.refresh_token = nil
+          self.refresh_token = self.class.create_refresh_token(client)
           save!
         end
 

--- a/spec/songkick/oauth2/model/authorization_spec.rb
+++ b/spec/songkick/oauth2/model/authorization_spec.rb
@@ -135,22 +135,24 @@ describe Songkick::OAuth2::Model::Authorization do
   end
 
   describe "#exchange!" do
+    before { authorization }
+
     it "saves the record" do
       authorization.should_receive(:save!)
       authorization.exchange!
     end
 
     it "uses its helpers to find unique tokens" do
-      Songkick::OAuth2::Model::Authorization.should_receive(:create_access_token).and_return('access_token')
+      Songkick::OAuth2.stub(:random_string).and_return('access_token', 'refresh_token')
       authorization.exchange!
       authorization.access_token.should == 'access_token'
+      authorization.refresh_token.should == 'refresh_token'
     end
 
     it "updates the tokens correctly" do
       authorization.exchange!
       authorization.should be_valid
       authorization.code.should be_nil
-      authorization.refresh_token.should be_nil
     end
   end
 

--- a/spec/songkick/oauth2/provider_spec.rb
+++ b/spec/songkick/oauth2/provider_spec.rb
@@ -388,9 +388,13 @@ describe Songkick::OAuth2::Provider do
         end
 
         it "returns a successful response" do
-          Songkick::OAuth2.stub(:random_string).and_return('random_access_token')
+          Songkick::OAuth2.stub(:random_string).and_return('random_access_token', 'random_refresh_token')
           response = post_basic_auth(auth_params, query_params)
-          validate_json_response(response, 200, 'access_token' => 'random_access_token', 'expires_in' => 10800)
+          validate_json_response(response, 200,
+            'access_token'  => 'random_access_token',
+            'refresh_token' => 'random_refresh_token',
+            'expires_in'    => 10800
+          )
         end
 
         describe "with a scope parameter" do
@@ -399,10 +403,11 @@ describe Songkick::OAuth2::Provider do
           end
 
           it "passes the scope back in the success response" do
-            Songkick::OAuth2.stub(:random_string).and_return('random_access_token')
+            Songkick::OAuth2.stub(:random_string).and_return('random_access_token', 'random_refresh_token')
             response = post_basic_auth(auth_params, query_params)
             validate_json_response(response, 200,
               'access_token'  => 'random_access_token',
+              'refresh_token' => 'random_refresh_token',
               'scope'         => 'foo bar',
               'expires_in'    => 10800
             )
@@ -437,13 +442,14 @@ describe Songkick::OAuth2::Provider do
       describe "when there is an Authorization with code and token" do
         before do
           @authorization.update_attributes(:code => 'pending_code', :access_token => 'working_token')
-          Songkick::OAuth2.stub(:random_string).and_return('random_access_token')
+          Songkick::OAuth2.stub(:random_string).and_return('random_access_token', 'random_refresh_token')
         end
 
         it "returns a new access token" do
           response = post(params)
           validate_json_response(response, 200,
             'access_token' => 'random_access_token',
+            'refresh_token' => 'random_refresh_token',
             'expires_in'   => 10800
           )
         end


### PR DESCRIPTION
Include a refresh token when exchanging an access grant for an access token. With a refresh token, a client can obtain a new access token without having to request another access grant.

This branch completes the work for a feature requested by issues #15, #23, and #70.

Tests pass with #74.