### PR TITLE
Rails 4 count

### DIFF
--- a/lib/songkick/oauth2/model/client.rb
+++ b/lib/songkick/oauth2/model/client.rb
@@ -1,58 +1,58 @@
 module Songkick
   module OAuth2
     module Model
-      
+
       class Client < ActiveRecord::Base
         self.table_name = :oauth2_clients
-        
+
         belongs_to :oauth2_client_owner, :polymorphic => true
         alias :owner  :oauth2_client_owner
         alias :owner= :oauth2_client_owner=
-            
+
         has_many :authorizations, :class_name => 'Songkick::OAuth2::Model::Authorization', :dependent => :destroy
-        
-        validates_uniqueness_of :client_id, :name
+
+        validates_uniqueness_of :client_id
         validates_presence_of   :name, :redirect_uri
         validate :check_format_of_redirect_uri
-        
+
         attr_accessible :name, :redirect_uri
-        
+
         before_create :generate_credentials
-        
+
         def self.create_client_id
           Songkick::OAuth2.generate_id do |client_id|
-            count(:conditions => {:client_id => client_id}).zero?
+            where(:client_id => client_id).count.zero?
           end
         end
-        
+
         attr_reader :client_secret
-        
+
         def client_secret=(secret)
           @client_secret = secret
           hash = BCrypt::Password.create(secret)
           hash.force_encoding('UTF-8') if hash.respond_to?(:force_encoding)
           self.client_secret_hash = hash
         end
-        
+
         def valid_client_secret?(secret)
           BCrypt::Password.new(client_secret_hash) == secret
         end
-        
+
       private
-        
+
         def check_format_of_redirect_uri
           uri = URI.parse(redirect_uri)
           errors.add(:redirect_uri, 'must be an absolute URI') unless uri.absolute?
         rescue
           errors.add(:redirect_uri, 'must be a URI')
         end
-        
+
         def generate_credentials
           self.client_id = self.class.create_client_id
           self.client_secret = Songkick::OAuth2.random_string
         end
       end
-      
+
     end
   end
 end

--- a/lib/songkick/oauth2/model/client.rb
+++ b/lib/songkick/oauth2/model/client.rb
@@ -11,7 +11,7 @@ module Songkick
 
         has_many :authorizations, :class_name => 'Songkick::OAuth2::Model::Authorization', :dependent => :destroy
 
-        validates_uniqueness_of :client_id
+        validates_uniqueness_of :client_id, :name
         validates_presence_of   :name, :redirect_uri
         validate :check_format_of_redirect_uri
 

--- a/songkick-oauth2-provider.gemspec
+++ b/songkick-oauth2-provider.gemspec
@@ -1,6 +1,6 @@
 spec = Gem::Specification.new do |s|
   s.name              = "songkick-oauth2-provider"
-  s.version           = "0.10.2"
+  s.version           = "0.10.3"
   s.summary           = "Simple OAuth 2.0 provider toolkit"
   s.author            = "James Coglan"
   s.email             = "james@songkick.com"


### PR DESCRIPTION
`count(:conditions)` is no longer supported with Rails 4. Using the `where(conditions).count` instead.