### PR TITLE
Remove duplicate ActiveRecord dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,7 @@
 source 'https://rubygems.org'
-gemspec
 
+group :development do
+  gem 'activerecord', '>= 3.2.0' # The SQLite adapter in 3.1 is broken
+end
+
+gemspec

--- a/songkick-oauth2-provider.gemspec
+++ b/songkick-oauth2-provider.gemspec
@@ -1,4 +1,4 @@
-spec = Gem::Specification.new do |s|
+Gem::Specification.new do |s|
   s.name              = 'songkick-oauth2-provider'
   s.version           = '0.10.2'
   s.summary           = 'Simple OAuth 2.0 provider toolkit'
@@ -28,4 +28,3 @@ spec = Gem::Specification.new do |s|
   s.add_development_dependency 'thin'
   s.add_development_dependency 'factory_girl', '~> 2.0'
 end
-

--- a/songkick-oauth2-provider.gemspec
+++ b/songkick-oauth2-provider.gemspec
@@ -18,13 +18,12 @@ Gem::Specification.new do |s|
   s.add_dependency 'rack'
 
   s.add_development_dependency 'appraisal', '~> 0.4.0'
-  s.add_development_dependency 'activerecord', '~> 3.2.0' # The SQLite adapter in 3.1 is broken
+  s.add_development_dependency 'factory_girl', '~> 2.0'
   s.add_development_dependency 'i18n', '~> 0.6.4'
   s.add_development_dependency 'mysql', '~> 2.8.0' if ENV['DB'] == 'mysql' # version locked by ActiveRecord
   s.add_development_dependency 'pg' if ENV['DB'] == 'postgres'
   s.add_development_dependency 'rspec'
-  s.add_development_dependency 'sqlite3'
   s.add_development_dependency 'sinatra', '>= 1.3.0'
+  s.add_development_dependency 'sqlite3'
   s.add_development_dependency 'thin'
-  s.add_development_dependency 'factory_girl', '~> 2.0'
 end


### PR DESCRIPTION
:information_desk_person: The gemspec defines ActiveRecord as a dependency twice, the second of which attempts to ensure that a compatible version is available for development. Migrating this version lock to the Gemfile results in the same behaviour, without the inconvenience of Bundler >= v1.10.1 refusing to install the gem due to an invalid gemspec.

An example of this error message follows:
```
/opt/rubies/2.2.2/gems/bundler-1.10.3/lib/bundler.rb:374:in `rescue in load_gemspec_uncached':
The gemspec at /www/sites/demo/vendor/bundle/ruby/2.2.2/bundler/gems/oauth2-provider-b60ea985a0e9/songkick-oauth2-provider.gemspec
is not valid. The validation error was 'duplicate dependency on activerecord (~> 3.2.0, development), (>= 0) use: (Bundler::InvalidOption)
    add_runtime_dependency 'activerecord', '~> 3.2.0', '>= 0'
```